### PR TITLE
Patching multi-skymap bug

### DIFF
--- a/blip/src/fast_geometry.py
+++ b/blip/src/fast_geometry.py
@@ -519,7 +519,7 @@ class fast_geometry(sph_geometry):
                     if fullsky:
                         sm_map = sm.skymap
                     else:
-                        sm_map = sm.skymap[np.flatnonzero(sm.skymap)]
+                        sm_map = sm.skymap[pix_idx]
                     ## normalize skymap such that integral of P(n)d2n = 1
                     sm_map = sm_map/(np.sum(sm_map)*self.dOmega)
                     sm.response_args = sm_map


### PR DESCRIPTION
Fixing an issue where convolving skymaps with the LISA response fails for the case multiple ASGWB models. Astrophysical skymaps will now mask to the number of pixels that are nonzero in **all** skymaps being simulated.