### PR TITLE
Optimization: casting pixel responses to float64 after computation

### DIFF
--- a/blip/run_blip
+++ b/blip/run_blip
@@ -717,7 +717,7 @@ def blip(paramsfile='params.ini',resume=False):
             ## step through the (possibly multiple) populations and tweak formatting for the delimiters
             ## also enforce the required keys and substitute defaults if optional setting isn't given
             required_keys = ['popfile','columns','delimiter']
-            pop_defaults = {'snr_cut':7,'name':None}
+            pop_defaults = {'snr_cut':7,'name':None,'coldict':None}
             for key in inj['popdict'].keys():
                 ## make sure it corresponds to an injection
                 if key not in inj_component_names:

--- a/blip/src/astro.py
+++ b/blip/src/astro.py
@@ -48,7 +48,10 @@ class Population():
         self.popdict = popdict
         
         ## load the population
-        pop = self.load_population(self.popdict['popfile'],self.params['fmin'],self.params['fmax'],names=self.popdict['columns'],sep=self.popdict['delimiter'])
+        if self.popdict['coldict'] is None:
+            pop = self.load_population(self.popdict['popfile'],self.params['fmin'],self.params['fmax'],names=self.popdict['columns'],sep=self.popdict['delimiter'])
+        else:
+            pop = self.load_population(self.popdict['popfile'],self.params['fmin'],self.params['fmax'],names=self.popdict['columns'],sep=self.popdict['delimiter'],coldict=self.popdict['coldict'])
         
         ## get the skymap
         self.skymap = self.pop2map(pop,self.params['nside'],self.params['dur']*u.s,self.params['fmin'],self.params['fmax'])

--- a/blip/src/astro.py
+++ b/blip/src/astro.py
@@ -62,7 +62,7 @@ class Population():
         ## spectrum
         if not map_only:
             ## PSD at injection frequency binning
-            self.PSD = self.pop2spec(pop,self.frange,self.params['dur']*u.s,SNR_cut=self.popdict['snr_cut'],return_median=False,plot=False)
+            self.PSD = self.pop2spec(pop,self.frange,self.params['dur']*u.s,SNR_cut=self.popdict['snr_cut'],return_median=False,plot=False) #True,saveto=self.params['out_dir'])
     
             ## PSD at data frequencies
             self.fftfreqs = np.fft.rfftfreq(int(self.params['fs']*self.params['seglen']),1/self.params['fs'])[1:]
@@ -169,7 +169,7 @@ class Population():
         Returns:
             binary_psds (1D array of floats): Monochromatic PSDs for each binary
         '''
-        binary_psds = 0.5*t_obs*hs**2
+        binary_psds = t_obs*hs**2
         
         return binary_psds
     
@@ -240,10 +240,9 @@ class Population():
         PSDs_unres = cls.get_binary_psd(hs,4*u.yr)
         
         ## get BLIP frequency bins
-        log_frange = np.log10(frange)
-        log_bin_width = log_frange[1]-log_frange[0]
-        bins = 10**np.append(log_frange-log_bin_width/2,log_frange[-1]+log_bin_width/2)
-        bin_widths = bins[1:] - bins[:-1]
+        bin_width = frange[1] - frange[0]
+        bin_widths = bin_width
+        bins = np.append(frange - bin_width/2,frange[-1]+bin_width/2)
         
         ## check minimum frequency resolution
         ## set minimum bin width to delta_f = 1/T_obs
@@ -300,14 +299,12 @@ class Population():
             plt.savefig(saveto + '/population_injection_zoom.png', dpi=150)
             plt.close()
         
-        
-        ## factor of 1/2 is for phase-averaging to account for interference
         if return_median:
-            spectrum =  0.5*fg_PSD_binned/bin_widths *u.Hz*u.s
-            median_spectrum = 0.5*runmed_binned/bin_widths *u.Hz*u.s
+            spectrum =  fg_PSD_binned/bin_widths *u.Hz*u.s
+            median_spectrum = runmed_binned/bin_widths *u.Hz*u.s
             return spectrum, median_spectrum
         else:
-            spectrum =  0.5*fg_PSD_binned/bin_widths *u.Hz*u.s
+            spectrum =  fg_PSD_binned/bin_widths *u.Hz*u.s
             return spectrum
      
     @staticmethod

--- a/blip/src/fast_geometry.py
+++ b/blip/src/fast_geometry.py
@@ -257,6 +257,10 @@ class fast_geometry(sph_geometry):
                 if (sm.response_wrapper_func == self.wrappers[jj][0]) and np.array_equal(rargs,self.wrappers[jj][1]):
                     if not self.plot_flag:
                         sm.response_mat = self.unique_responses[jj]
+                        ## reduce memory usage of the parameterized pixel-basis models by casting to real float64
+                        ## do need to be careful with this because we need complex128 for the spherical harmonic models
+                        if hasattr(sm,"basis") and sm.basis=='pixel':
+                            sm.response_mat = xp.real(sm.response_mat)
                         ## FIX LATER --- aliasing for now, should standardize everything to sm.response_mat later
                         sm.summ_response_mat = sm.response_mat 
                         if sm.injection:

--- a/params_default.ini
+++ b/params_default.ini
@@ -55,8 +55,6 @@ model=noise+powerlaw_isgwb
 
 alias={'powerlaw_isgwb':'powerlaw_isgwb'}
 
-## Hierarchical setup. Only fg_scale_heights_full is currently supported.
-hierarchy=fg_scale_heights_full
 ## spherical harmonic lmax for the b_lms (a_lmax/2)
 lmax = 2
 

--- a/params_test.ini
+++ b/params_test.ini
@@ -131,13 +131,10 @@ truevals = {'noise':{'Np':9e-42,'Na':3.6e-49},
 # Population injection
 # (these settings also apply to the spatial population injection below)
 # Data file
-popfile=/mnt/c/Users/Alexander/Documents/LISA/LISA_data/DWD_FullPopulation_Wilhelm_etal_2020_30deg.txt
-# Column names (comma-delineated, no spaces)
-columns=f,fdot,lat,long,h,i,pol,phase
-# Delimiter used in data file. For tab- and space-delimited files, enter tab or space, respectively
-delimiter=space
-# SNR cut used to determine resolved vs. unresolved sources
-SNRcut=7
+population_params={'population':{'popfile':'/datadisk/data/LISA/DWD_FullPopulation_Wilhelm_etal_2020_30deg.txt',
+				   'columns':['f','fdot','lat','long','h','i','pol','phase'],
+				   'delimiter':'space',
+				   'snr_cut':7}}
 
 
 [run_params] # Parameters related to the run or to the sampler


### PR DESCRIPTION
For the pixel basis, we do not need to carry the full complex response, as the skymaps are real. We do need the response to be complex for the spherical harmonic basis, so we only cast to real for the pixel-basis models. This saves a factor of two in RAM, effectively doubling what we can analyze with the RAM-intensive parameterized pixel models.